### PR TITLE
Slideshow: Responsive admin pages

### DIFF
--- a/components/Admin/Sidebar.js
+++ b/components/Admin/Sidebar.js
@@ -6,23 +6,26 @@
 import Link from 'next/link'
 import { withRouter } from 'next/router'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faTv } from '@fortawesome/free-solid-svg-icons'
+import { faTv, faThLarge, faImages, faSignOutAlt } from '@fortawesome/free-solid-svg-icons'
 
 const MENU = [
   {
     id: 'layout',
     name: 'Layout',
-    path: '/layout'
+    path: '/layout',
+    icon: faThLarge
   },
   {
     id: 'preview',
     name: 'Preview',
-    path: '/preview'
+    path: '/preview',
+    icon: faTv
   },
   {
     id: 'slideshow',
     name: 'Slideshows',
-    path: '/slideshows'
+    path: '/slideshows',
+    icon: faImages
   }
 ]
 
@@ -41,14 +44,23 @@ const Sidebar = ({ router }) => (
       {MENU.map(item => (
         <Link href={item.path}>
           <li className={item.path == router.pathname && 'active'}>
-            <a>{item.name}</a>
+            <a>
+              <FontAwesomeIcon icon={item.icon} fixedWidth />
+              <span className={'text'}>
+                {'   '}
+                {item.name}
+              </span>
+            </a>
           </li>
         </Link>
       ))}
     </ul>
     <Link href={'/'}>
       <div className="logout">
-        <a>Logout</a>
+        <a>
+          <FontAwesomeIcon icon={faSignOutAlt} fixedWidth />
+          <span className={'text'}>{'   Logout'}</span>
+        </a>
       </div>
     </Link>
     <style jsx>
@@ -125,6 +137,18 @@ const Sidebar = ({ router }) => (
           vertical-align: middle;
           line-height: 16px;
           padding-right: 4px;
+        }
+        @media only screen and (max-width: 600px) {
+          .sidebar {
+            min-width: 0px;
+          }
+          .logo {
+            display: none;
+          }
+          .menu li .text,
+          .logout .text {
+            display: none;
+          }
         }
       `}
     </style>

--- a/components/Admin/Sidebar.js
+++ b/components/Admin/Sidebar.js
@@ -33,7 +33,7 @@ const Sidebar = ({ router }) => (
   <div className="sidebar">
     <div className="logo">
       <div className="icon">
-        <FontAwesomeIcon icon={faTv} size="3x" fixedWidth color="#7bc043" />
+        <FontAwesomeIcon icon={faTv} fixedWidth color="#7bc043" />
       </div>
       <div className="info">
         <span className="name">Acopian Fifth Floor</span>
@@ -112,6 +112,7 @@ const Sidebar = ({ router }) => (
           display: flex;
           justify-content: center;
           align-items: center;
+          transform: scale(2);
         }
         .logo .info {
           font-family: 'Open Sans', sans-serif;
@@ -142,8 +143,17 @@ const Sidebar = ({ router }) => (
           .sidebar {
             min-width: 0px;
           }
-          .logo {
+          .logo .info {
             display: none;
+          }
+          .logo .icon {
+            min-width: 0px;
+            min-height: 0px;
+            transform: scale(1);
+          }
+          .logo {
+            margin: 0px;
+            padding: 0px;
           }
           .menu li .text,
           .logout .text {

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -15,6 +15,7 @@ class AppDocument extends Document {
       <html>
         <Head>
           <style>{`body { margin: 0 } /* custom! */`}</style>
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
           <link
             href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700,800"
             rel="stylesheet"


### PR DESCRIPTION
This PR allows the Sidebar of the admin panel to become compact on smaller screens in order to make the pages responsive on mobile phones.

### Changes
- Added a viewport meta tag
- Added icons to the admin sidebar menu items
- Changed the sidebar's styles to become responsive

### Screenshots
<img width="981" alt="screen shot 2019-03-07 at 1 17 12 pm" src="https://user-images.githubusercontent.com/591655/53979311-749d6b80-40db-11e9-9bcf-a652b4ddd899.png">
<img width="358" alt="screen shot 2019-03-07 at 1 16 56 pm" src="https://user-images.githubusercontent.com/591655/53979282-5cc5e780-40db-11e9-9eab-a2413d66b8c1.png">
