### PR TITLE
Caches slides and adds opacity animation

### DIFF
--- a/components/Slideshow/Slide.js
+++ b/components/Slideshow/Slide.js
@@ -75,11 +75,25 @@ class Slide extends Component {
   }
 
   /**
+   * Stops the slide's content from playing when the slide is out of focus
+   */
+  stop = () => {
+    console.log('Slide stopped')
+  }
+
+  /**
+   * Starts or resumes the slide's content when the slide is in focus
+   */
+  play = () => {
+    console.log('Slide played')
+  }
+
+  /**
    * Renders the slide along with an overlayed title and description if given
    * @returns {Component}
    */
   render() {
-    const { slide } = this.props
+    const { slide, show = false } = this.props
     const { data, type, title, desc } = slide
     return (
       <div className="slide">
@@ -129,6 +143,8 @@ class Slide extends Component {
             height: 100%;
             width: 100%;
             position: absolute;
+            opacity: ${show ? 1 : 0};
+            transition: opacity 0.4s;
           }
         `}</style>
       </div>

--- a/components/Slideshow/Slide.js
+++ b/components/Slideshow/Slide.js
@@ -78,14 +78,14 @@ class Slide extends Component {
    * Stops the slide's content from playing when the slide is out of focus
    */
   stop = () => {
-    console.log('Slide stopped')
+    // TODO(@wassgha) Execute code to stop slide content
   }
 
   /**
    * Starts or resumes the slide's content when the slide is in focus
    */
   play = () => {
-    console.log('Slide played')
+    // TODO(@wassgha) Execute code to resume/restart slide content
   }
 
   /**

--- a/components/Slideshow/Slideshow.js
+++ b/components/Slideshow/Slideshow.js
@@ -4,7 +4,7 @@
  * the given durations
  */
 
-import { Component } from 'react'
+import React, { Component } from 'react'
 import _ from 'lodash'
 
 import Slide from './Slide'
@@ -15,6 +15,8 @@ const DEFAULT_DURATION = 5000
 class Slideshow extends Component {
   constructor(props) {
     super(props)
+
+    this.slideRefs = []
 
     this.state = {
       current: null
@@ -47,7 +49,13 @@ class Slideshow extends Component {
         {
           current: (current + 1) % slides.length
         },
-        resolve
+        () => {
+          const { current } = this.state
+          const prev = (((current - 1) % slides.length) + slides.length) % slides.length
+          this.slideRefs[prev].stop()
+          this.slideRefs[current].play()
+          resolve()
+        }
       )
     })
   }
@@ -70,11 +78,17 @@ class Slideshow extends Component {
   render() {
     const { defaultDuration = DEFAULT_DURATION } = this.props
     const { current } = this.state
-    const currentSlide = this.orderedSlides[current]
     return (
       <div className="slideshow">
         <div className="slideshow-wrapper">
-          {currentSlide && <Slide key={current} slide={currentSlide} />}
+          {this.orderedSlides.map((slide, index) => (
+            <Slide
+              key={index}
+              slide={slide}
+              show={index == current}
+              ref={ref => (this.slideRefs[index] = ref)}
+            />
+          ))}
         </div>
         <Progress
           defaultDuration={defaultDuration}
@@ -93,6 +107,7 @@ class Slideshow extends Component {
               position: relative;
               width: 100%;
               height: 100%;
+              overflow: hidden;
             }
           `}
         </style>


### PR DESCRIPTION
Closes #26 

Instead of re-loading each slide every time a new slide is displayed, all slides are loaded at the begining and their opacity is simply switched based on which slide is in focus. This reduces load time and lag (especially for web pages and videos) and adds a nice fade-out effect between slides.