### PR TITLE
Slideshow: Refactors slides code and fixes multiple bugs

### DIFF
--- a/components/Slideshow/Progress.js
+++ b/components/Slideshow/Progress.js
@@ -7,17 +7,19 @@ import { Component } from 'react'
 
 class Progress extends Component {
   render() {
-    const { current, defaultDuration, orderedSlides } = this.props
+    const { current, defaultDuration, orderedSlides, ready } = this.props
     return (
-      <div className="progress-bar">
+      <div className='progress-bar'>
         {orderedSlides.map((slide, i) => (
           <div key={`slide-${i}`} className={`progress-segment ${i < current && 'active'}`}>
             <div
               className={`progress-segment-content`}
               style={{
-                width: i == current ? '100%' : '0%',
+                width: i == current && ready ? '100%' : '0%',
                 transition:
-                  i == current ? `all linear ${slide.duration || defaultDuration / 1000}s` : 'none'
+                  i == current && ready
+                    ? `all linear ${slide.duration || defaultDuration / 1000}s`
+                    : 'none'
               }}
             />
           </div>

--- a/components/Slideshow/Slide/Generic.js
+++ b/components/Slideshow/Slide/Generic.js
@@ -3,75 +3,65 @@
  * along with its title and description.
  */
 
-import { Component } from 'react'
-import getVideoId from 'get-video-id'
+import React, { Component } from 'react'
 
-class Slide extends Component {
+class GenericSlide extends Component {
+  constructor(props) {
+    super(props)
+
+    const loading = {
+      promise: null,
+      resolve: null,
+      reject: null,
+      done: null
+    }
+
+    loading.promise = new Promise((resolve, reject) => {
+      loading.resolve = resolve
+      loading.reject = reject
+    }).then(() => this.setState({ loaded: true }))
+
+    this.state = {
+      loading: { ...loading },
+      loaded: false
+    }
+  }
+
+  componentDidMount() {
+    this.state.loading.resolve()
+  }
+
+  get loadedPromise() {
+    return this.state.loading.promise
+  }
+
+  get loaded() {
+    return this.state.loaded
+  }
+
   /**
    * Renders the inner content of the slide (ex. the photo, youtube iframe, etc)
-   * @param {string} type Slide type (ex. photo, youtube, web, etc.)
    * @param {string} data The slide's data (usually a URL or object ID)
    * @returns {Component}
    */
-  renderSlideContent(type, data) {
-    switch (type) {
-      case 'photo':
-        return (
-          <div
-            className="slide-content photo"
-            style={{
-              backgroundImage: `url(${data})`
-            }}
-          >
-            <style jsx>{`
-              .slide-content.photo {
-                width: 100%;
-                height: 100%;
-                background-size: cover;
-                background-repeat: no-repeat;
-                background-position: 50% 50%;
-              }
-            `}</style>
-          </div>
-        )
-      case 'youtube':
-        const { id, service } = getVideoId(data)
-        if (id && service == 'youtube') {
-          return (
-            <iframe
-              width="100%"
-              height="100%"
-              src={`https://www.youtube.com/embed/${id}?autoplay=1&controls=0&start=18`}
-              frameborder="0"
-              allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-              allowfullscreen
-            />
-          )
-        }
-      case 'web':
-        return (
-          <iframe
-            width="100%"
-            height="100%"
-            src={data}
-            frameborder="0"
-            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-            allowfullscreen
-          />
-        )
-      default:
-        return (
-          <div className="slide-content unknown">
-            <style jsx>{`
-              .slide-content.unknown {
-                width: 100%;
-                height: 100%;
-                background: #ebebeb;
-              }
-            `}</style>
-          </div>
-        )
-    }
+  renderSlideContent(data) {
+    return (
+      <div className='slide-content unknown'>
+        {`Unknown slide type with data: ${data}`}
+        <style jsx>{`
+          .slide-content.unknown {
+            width: 100%;
+            height: 100%;
+            background: #ebebeb;
+            color: #333;
+            text-align: center;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+          }
+        `}</style>
+      </div>
+    )
   }
 
   /**
@@ -94,12 +84,13 @@ class Slide extends Component {
    */
   render() {
     const { slide, show = false } = this.props
-    const { data, type, title, desc } = slide
+    const { data, title, desc } = slide
+    const { loaded } = this.state
     return (
-      <div className="slide">
-        {this.renderSlideContent(type, data)}
+      <div className='slide'>
+        {this.renderSlideContent(data)}
         {(title || desc) && (
-          <div className="info">
+          <div className='info'>
             {title && <h1>{title}</h1>}
             {desc && <p>{desc}</p>}
           </div>
@@ -144,7 +135,8 @@ class Slide extends Component {
             width: 100%;
             position: absolute;
             opacity: ${show ? 1 : 0};
-            transition: opacity 0.4s;
+            filter: ${loaded ? 'none' : 'blur(40px)'};
+            transition: all 0.4s;
           }
         `}</style>
       </div>
@@ -152,4 +144,4 @@ class Slide extends Component {
   }
 }
 
-export default Slide
+export default GenericSlide

--- a/components/Slideshow/Slide/Photo.js
+++ b/components/Slideshow/Slide/Photo.js
@@ -1,0 +1,84 @@
+/**
+ * @fileoverview Slide component that given a slide type and its data renders it
+ * along with its title and description.
+ */
+
+import GenericSlide from './Generic'
+import React from 'react'
+
+class PhotoSlide extends GenericSlide {
+  constructor(props) {
+    super(props)
+
+    this.image = React.createRef()
+  }
+
+  componentDidMount() {
+    if (this.image && this.image.current && this.image.current.complete) {
+      this.handleImageLoaded()
+    }
+  }
+
+  handleImageLoaded = () => {
+    this.state.loading.resolve
+      ? this.state.loading.resolve()
+      : this.setState({ loading: { promise: Promise.resolve() } })
+  }
+
+  handleImageErrored = () => {
+    this.state.loading.reject
+      ? this.state.loading.reject()
+      : this.setState({ loading: { promise: Promise.reject() } })
+  }
+
+  /**
+   * Renders the inner content of the slide (ex. the photo, youtube iframe, etc)
+   * @param {string} data The slide's data (usually a URL or object ID)
+   * @returns {Component}
+   */
+  renderSlideContent(data) {
+    return (
+      <div
+        className='slide-content photo'
+        style={{
+          backgroundImage: `url(${data})`
+        }}
+      >
+        <img
+          src={data}
+          className='slide-content invisible'
+          onLoad={this.handleImageLoaded.bind(this)}
+          onError={this.handleImageErrored.bind(this)}
+          ref={this.image}
+        />
+        <style jsx>{`
+          .slide-content.photo {
+            width: 100%;
+            height: 100%;
+            background-size: cover;
+            background-repeat: no-repeat;
+            background-position: 50% 50%;
+          }
+          .slide-content.invisible {
+            width: 1px;
+            height: 1px;
+            display: none;
+            visibility: hidden;
+          }
+        `}</style>
+      </div>
+    )
+  }
+
+  /**
+   * Stops the slide's content from playing when the slide is out of focus
+   */
+  stop = () => {}
+
+  /**
+   * Starts or resumes the slide's content when the slide is in focus
+   */
+  play = () => {}
+}
+
+export default PhotoSlide

--- a/components/Slideshow/Slide/Web.js
+++ b/components/Slideshow/Slide/Web.js
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview Slide component that given a slide type and its data renders it
+ * along with its title and description.
+ */
+
+import GenericSlide from './Generic'
+
+class WebSlide extends GenericSlide {
+  constructor(props) {
+    super(props)
+  }
+
+  componentDidMount() {
+    this.state.loading.resolve()
+  }
+
+  /**
+   * Renders the inner content of the slide (ex. the photo, youtube iframe, etc)
+   * @param {string} data The slide's data (usually a URL or object ID)
+   * @returns {Component}
+   */
+  renderSlideContent(data) {
+    return (
+      <iframe
+        width='100%'
+        height='100%'
+        src={data}
+        frameborder='0'
+        allow='accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture'
+        allowfullscreen
+      />
+    )
+  }
+
+  /**
+   * Stops the slide's content from playing when the slide is out of focus
+   */
+  stop = () => {}
+
+  /**
+   * Starts or resumes the slide's content when the slide is in focus
+   */
+  play = () => {}
+}
+
+export default WebSlide

--- a/components/Slideshow/Slide/Youtube.js
+++ b/components/Slideshow/Slide/Youtube.js
@@ -32,6 +32,7 @@ class YoutubeSlide extends GenericSlide {
    */
   renderSlideContent(data) {
     const { id, service } = getVideoId(data)
+    /* eslint-disable-next-line no-console */
     if (!id || service !== 'youtube') console.error('Failed to parse Youtube URL')
     return (
       <div className={'youtube-container'}>
@@ -39,6 +40,7 @@ class YoutubeSlide extends GenericSlide {
           containerClassName={'youtube-container-nojsx'}
           videoId={id}
           opts={{
+            /* eslint-disable camelcase */
             height: '100%',
             width: '100%',
             playerVars: {
@@ -52,6 +54,7 @@ class YoutubeSlide extends GenericSlide {
               rel: 0,
               showinfo: 0
             }
+            /* eslint-enable camelcase */
           }}
           onReady={this.onYoutubeReady}
         />

--- a/components/Slideshow/Slide/Youtube.js
+++ b/components/Slideshow/Slide/Youtube.js
@@ -1,0 +1,95 @@
+/**
+ * @fileoverview Slide component that given a slide type and its data renders it
+ * along with its title and description.
+ */
+
+import GenericSlide from './Generic'
+import getVideoId from 'get-video-id'
+import YouTube from 'react-youtube'
+
+class YoutubeSlide extends GenericSlide {
+  constructor(props) {
+    super(props)
+    this.youtube = null
+  }
+
+  handleYoutubeLoaded = () => {
+    this.state.loading.resolve
+      ? this.state.loading.resolve()
+      : this.setState({ loading: { promise: Promise.resolve() } })
+  }
+
+  onYoutubeReady = event => {
+    // access to player in all event handlers via event.target
+    this.youtube = event.target
+    this.handleYoutubeLoaded()
+  }
+
+  /**
+   * Renders the inner content of the slide (ex. the photo, youtube iframe, etc)
+   * @param {string} data The slide's data (usually a URL or object ID)
+   * @returns {Component}
+   */
+  renderSlideContent(data) {
+    const { id, service } = getVideoId(data)
+    if (!id || service !== 'youtube') console.error('Failed to parse Youtube URL')
+    return (
+      <div className={'youtube-container'}>
+        <YouTube
+          containerClassName={'youtube-container-nojsx'}
+          videoId={id}
+          opts={{
+            height: '100%',
+            width: '100%',
+            playerVars: {
+              autoplay: 0,
+              controls: 0,
+              start: 0,
+              cc_load_policy: 0,
+              fs: 0,
+              iv_load_policy: 3,
+              modestbranding: 1,
+              rel: 0,
+              showinfo: 0
+            }
+          }}
+          onReady={this.onYoutubeReady}
+        />
+        <style>
+          {`
+                .youtube-container-nojsx {
+                  width: 100%;
+                  height: 100%;
+                  min-height: 100%;
+                }
+              `}
+        </style>
+        <style jsx>
+          {`
+            .youtube-container {
+              width: 100%;
+              height: 100%;
+              min-height: 100%;
+            }
+          `}
+        </style>
+      </div>
+    )
+  }
+
+  /**
+   * Stops the slide's content from playing when the slide is out of focus
+   */
+  stop = () => {
+    if (this.youtube) this.youtube.pauseVideo() && this.youtube.seekTo(0)
+  }
+
+  /**
+   * Starts or resumes the slide's content when the slide is in focus
+   */
+  play = () => {
+    if (this.youtube) this.youtube.playVideo()
+  }
+}
+
+export default YoutubeSlide

--- a/components/Slideshow/Slideshow.js
+++ b/components/Slideshow/Slideshow.js
@@ -74,7 +74,6 @@ class Slideshow extends Component {
     const { current } = this.state
     const currentSlide = this.orderedSlides[current]
     this.setState({ ready: false }, () => {
-      console.log('this.slideRefs', this.slideRefs)
       this.slideRefs[current].loadedPromise.then(() => {
         this.setState({ ready: true })
         setTimeout(

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-dom": "^16.8.2",
     "react-dropzone": "^10.0.0",
     "react-live-clock": "^3.1.0",
-    "react-markdown": "^4.0.6"
+    "react-markdown": "^4.0.6",
+    "react-youtube": "^7.9.0"
   }
 }


### PR DESCRIPTION
This PR splits code for the different slide types into multiple files (a file for each type, for now) and implements logic for managing when slides would stop/start based on whether they are hidden or displayed.

### Changes
- Splits the `Slide.js` file into `Slide/*` files for each type
- Creates an inheritance structure with `GenericSlide` being the parent component and every other slide type inherits from it
- Fix: The slideshow will now wait for a slide to finish loading before it starts the timer
- Fix: Youtube videos will now restart every time they are displayed again