### PR TITLE
Fontawesome FOUC fix

### DIFF
--- a/components/Admin/Widgets/EditableWidget.js
+++ b/components/Admin/Widgets/EditableWidget.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { library } from '@fortawesome/fontawesome-svg-core'
+import { library, config } from '@fortawesome/fontawesome-svg-core'
 import {
   faPlay,
   faFont,
@@ -11,6 +11,7 @@ import {
   faTimes
 } from '@fortawesome/free-solid-svg-icons'
 
+config.autoAddCss = false
 library.add(faList)
 library.add(faPlay)
 library.add(faFont)
@@ -26,7 +27,7 @@ class EditableWidget extends React.Component {
     return (
       <div className={'widget'}>
         <div className={'delete'} onClick={onDelete}>
-          <FontAwesomeIcon icon={faTimes} size={'s'} fixedWidth />
+          <FontAwesomeIcon icon={faTimes} size={'xs'} fixedWidth />
         </div>
         <div className={'info'}>
           <div className={'icon'}>

--- a/components/DropdownButton.js
+++ b/components/DropdownButton.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { library } from '@fortawesome/fontawesome-svg-core'
+import { library, config } from '@fortawesome/fontawesome-svg-core'
 import {
   faPlay,
   faFont,
@@ -10,6 +10,7 @@ import {
   faPlus
 } from '@fortawesome/free-solid-svg-icons'
 
+config.autoAddCss = false
 library.add(faPlus)
 library.add(faList)
 library.add(faPlay)

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "react-markdown": "^4.0.6",
     "react-modal": "^3.8.1",
     "react-sortable-hoc": "^1.8.3",
-    "react-youtube": "^7.9.0"
+    "react-youtube": "^7.9.0",
+    "styled-components": "^4.2.0"
   }
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -3,6 +3,7 @@ import React from 'react'
 
 import '../styles/GridLayoutStyles.css'
 import 'react-resizable/css/styles.css'
+import '@fortawesome/fontawesome-svg-core/styles.css'
 
 export default class NextApp extends App {
   static async getInitialProps({ Component, ctx }) {

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -3,23 +3,29 @@
  */
 
 import Document, { Head, Main, NextScript } from 'next/document'
+import { ServerStyleSheet } from 'styled-components'
+import flush from 'styled-jsx/server'
 
 class AppDocument extends Document {
-  static async getInitialProps(ctx) {
-    const initialProps = await Document.getInitialProps(ctx)
-    return { ...initialProps }
+  static getInitialProps({ renderPage }) {
+    const sheet = new ServerStyleSheet()
+    const page = renderPage(App => props => sheet.collectStyles(<App {...props} />))
+    const styleTags = sheet.getStyleElement()
+    const styles = flush()
+    return { ...page, styleTags, styles }
   }
 
   render() {
     return (
       <html>
         <Head>
-          <style>{'body { margin: 0 } /* custom! */'}</style>
           <meta name='viewport' content='width=device-width, initial-scale=1' />
+          <meta charSet='utf-8' />
           <link
             href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700,800'
             rel='stylesheet'
           />
+          {this.props.styleTags}
         </Head>
         <body>
           <Main />

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -19,6 +19,7 @@ class AppDocument extends Document {
     return (
       <html>
         <Head>
+          <style>{'body { margin: 0 } /* custom! */'}</style>
           <meta name='viewport' content='width=device-width, initial-scale=1' />
           <meta charSet='utf-8' />
           <link


### PR DESCRIPTION
Fixes an issue with loading css for fontawesome that caused a Flash of Unstyled Content (FOUC) to occur on the first time a page renders.

<img width="1242" alt="Screen Shot 2019-04-09 at 5 39 31 PM" src="https://user-images.githubusercontent.com/591655/55837168-8d3fdd80-5aee-11e9-9010-08121a281d38.png">
