### PR TITLE
Implements widget-dependent admin panels

### DIFF
--- a/actions/slideshow.js
+++ b/actions/slideshow.js
@@ -1,0 +1,9 @@
+import axios from 'axios'
+
+export const getSlideshows = (host = '') => {
+  return axios.get(host + '/api/v1/slideshow').then(res => {
+    if (res && res.data) {
+      return res.data
+    }
+  })
+}

--- a/actions/widgets.js
+++ b/actions/widgets.js
@@ -21,3 +21,11 @@ export const deleteWidget = (id, host = '') => {
 export const updateWidget = (id, data, host = '') => {
   return axios.put(host + '/api/v1/widgets/' + id, data)
 }
+
+export const getWidget = (id, host = '') => {
+  return axios.get(host + '/api/v1/widgets/' + id).then(res => {
+    if (res && res.data) {
+      return res.data
+    }
+  })
+}

--- a/components/Admin/EditableWidget.js
+++ b/components/Admin/EditableWidget.js
@@ -20,13 +20,23 @@ library.add(faCloudSun)
 library.add(faCalendar)
 
 import Widgets from '../../widgets'
+import WidgetEditDialog from './WidgetEditDialog'
 
 class EditableWidget extends React.Component {
+  constructor(props) {
+    super(props)
+    this.dialog = React.createRef()
+  }
+
+  open = () => {
+    this.dialog && this.dialog.current.open()
+  }
+
   render() {
-    const { type = 'slideshow', onDelete = () => {} } = this.props
+    const { type = 'slideshow', id, onDelete = () => {} } = this.props
     const widget = Widgets[type] || {}
     return (
-      <div className={'widget'}>
+      <div className={'widget'} onClick={this.open}>
         <div className={'delete'} onClick={onDelete}>
           <FontAwesomeIcon icon={faTimes} size={'xs'} fixedWidth />
         </div>
@@ -37,6 +47,7 @@ class EditableWidget extends React.Component {
           <span className={'type'}>{widget.name || 'Broken Widget'}</span>
           {/* <span className={'name'}>NEWS</span> */}
         </div>
+        <WidgetEditDialog ref={this.dialog} OptionsComponent={widget.Options} id={id} />
         <style jsx>
           {`
             .widget {
@@ -47,6 +58,7 @@ class EditableWidget extends React.Component {
               display: flex;
               flex-direction: column;
               justify-content: center;
+              cursor: pointer;
             }
             .widget .info {
               display: flex;

--- a/components/Admin/Sidebar.js
+++ b/components/Admin/Sidebar.js
@@ -42,7 +42,7 @@ const Sidebar = ({ router }) => (
     </div>
     <ul className='menu'>
       {MENU.map(item => (
-        <Link href={item.path}>
+        <Link href={item.path} key={item.path}>
           <li className={item.path == router.pathname && 'active'}>
             <a>
               <FontAwesomeIcon icon={item.icon} fixedWidth />

--- a/components/Admin/SlideEditDialog.js
+++ b/components/Admin/SlideEditDialog.js
@@ -1,0 +1,55 @@
+import React from 'react'
+import Dialog from '../Dialog'
+import { Form, Input, Button, ButtonGroup } from '../Form'
+
+class SlideEditDialog extends React.Component {
+  constructor() {
+    super()
+
+    this.state = {}
+  }
+
+  open = () => {
+    this.dialog && this.dialog.open()
+  }
+
+  close = () => {
+    this.dialog && this.dialog.close()
+  }
+
+  handleChange = (name, value) => {
+    this.setState({
+      [name]: value
+    })
+  }
+
+  render() {
+    return (
+      <Dialog ref={ref => (this.dialog = ref)}>
+        <Form>
+          <Input type={'text'} label={'Position'} name={'position'} onChange={this.handleChange} />
+          <Input type={'text'} label={'Media'} name={'media'} onChange={this.handleChange} />
+          <Input
+            type={'number'}
+            label={'Duration'}
+            name={'duration'}
+            onChange={this.handleChange}
+          />
+          <Input type={'text'} label={'Title'} name={'title'} onChange={this.handleChange} />
+          <Input
+            type={'textarea'}
+            label={'Description'}
+            name={'description'}
+            onChange={this.handleChange}
+          />
+        </Form>
+        <ButtonGroup>
+          <Button text={'Save'} color={'#8bc34a'} onClick={this.close} />
+          <Button text={'Cancel'} color={'#e85454'} onClick={this.close} />
+        </ButtonGroup>
+      </Dialog>
+    )
+  }
+}
+
+export default SlideEditDialog

--- a/components/Admin/WidgetEditDialog.js
+++ b/components/Admin/WidgetEditDialog.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import Dialog from '../Dialog'
+import { Form, Button, ButtonGroup } from '../Form'
+import { getWidget, updateWidget } from '../../actions/widgets'
+
+class WidgetEditDialog extends React.Component {
+  constructor() {
+    super()
+
+    this.state = {}
+    this.dialog = React.createRef()
+  }
+
+  open = e => {
+    if (e) e.stopPropagation()
+    this.dialog && this.dialog.current && this.dialog.current.open()
+  }
+
+  close = e => {
+    if (e) e.stopPropagation()
+    this.dialog && this.dialog.current && this.dialog.current.close()
+  }
+
+  handleChange = data => {
+    this.setState({
+      data
+    })
+  }
+
+  saveData = () => {
+    const { id } = this.props
+    const { data } = this.state
+    updateWidget(id, { data }).then(() => {
+      this.close()
+    })
+  }
+
+  componentDidMount() {
+    const { id } = this.props
+    getWidget(id).then(({ data }) => this.setState({ data }))
+  }
+
+  render() {
+    const { OptionsComponent = Form } = this.props
+    const { data } = this.state
+    return (
+      <Dialog ref={this.dialog}>
+        <OptionsComponent data={data} onChange={this.handleChange} />
+        <ButtonGroup>
+          <Button text={'Save'} color={'#8bc34a'} onClick={this.saveData} />
+          <Button text={'Cancel'} color={'#e85454'} onClick={this.close} />
+        </ButtonGroup>
+      </Dialog>
+    )
+  }
+}
+
+export default WidgetEditDialog

--- a/components/Dialog.js
+++ b/components/Dialog.js
@@ -23,11 +23,13 @@ class Dialog extends React.Component {
     }
   }
 
-  open = () => {
+  open = e => {
+    if (e) e.stopPropagation()
     this.setState({ modalIsOpen: true })
   }
 
-  close = () => {
+  close = e => {
+    if (e) e.stopPropagation()
     this.setState({ modalIsOpen: false })
   }
 

--- a/components/Dialog.js
+++ b/components/Dialog.js
@@ -23,66 +23,25 @@ class Dialog extends React.Component {
     }
   }
 
-  openModal = () => {
+  open = () => {
     this.setState({ modalIsOpen: true })
   }
 
-  afterOpenModal = () => {}
-
-  closeModal = () => {
+  close = () => {
     this.setState({ modalIsOpen: false })
   }
 
-  handleInputChange = event => {
-    const target = event.target
-    const value = target.value
-    const name = target.name
-
-    this.setState({
-      [name]: value
-    })
-  }
-
   render() {
+    const { children } = this.props
     return (
       <div className='container'>
         <Modal
           isOpen={this.state.modalIsOpen}
-          onAfterOpen={this.afterOpenModal}
-          onRequestClose={this.closeModal}
+          onRequestClose={this.close}
           style={modalStyles}
+          ariaHideApp={false}
         >
-          <div className='form'>
-            <div className='inputGroup'>
-              <label>Position</label>
-              <input name='position' onChange={this.handleInputChange} />
-            </div>
-            <div className='inputGroup'>
-              <label>Media</label>
-              <input name='media' onChange={this.handleInputChange} />
-            </div>
-            <div className='inputGroup'>
-              <label>Duration</label>
-              <input name='duration' onChange={this.handleInputChange} type='number' />
-            </div>
-            <div className='inputGroup'>
-              <label>Title</label>
-              <input name='title' onChange={this.handleInputChange} />
-            </div>
-            <div className='inputGroup'>
-              <label>Description</label>
-              <textarea name='description' onChange={this.handleInputChange} />
-            </div>
-          </div>
-
-          <div className={'btnGroup'}>
-            <button className={'btn save'} onClick={this.closeModal}>
-              Save
-            </button>
-            <button className={'btn cancel'} onClick={this.closeModal}>
-              Cancel
-            </button>
-          </div>
+          <div className='form'>{children}</div>
         </Modal>
         <style jsx>{`
           .container {
@@ -97,79 +56,6 @@ class Dialog extends React.Component {
           .form {
             display: flex;
             flex-direction: column;
-          }
-
-          .form .inputGroup {
-            margin-bottom: 16px;
-            display: flex;
-            flex-direction: row;
-            justify-content: flex-start;
-          }
-
-          .form label {
-            margin-right: 16px;
-            color: #878787;
-            font-family: 'Open Sans', sans-serif;
-            min-width: 100px;
-            max-width: 100px;
-            display: inline-block;
-            padding-top: 16px;
-          }
-
-          .form input,
-          .form textarea {
-            background-color: #f7f7f7;
-            min-height: 40px;
-            min-width: 450px;
-            border-radius: 2px;
-            border: none;
-            outline: none;
-            padding: 8px;
-            padding-left: 16px;
-            padding-right: 16px;
-            font-size: 16px;
-          }
-
-          .form textarea {
-            resize: vertical;
-            min-height: 100px;
-          }
-
-          .form input[type='number'] {
-            min-width: 50px !important;
-            max-width: 50px !important;
-          }
-
-          .btnGroup {
-            display: flex;
-            flex-direction: row;
-            justify-content: flex-end;
-            flex: 1;
-          }
-
-          .btn {
-            font-family: 'Open Sans', sans-serif;
-            background: lightgray;
-            text-decoration: none;
-            text-transform: uppercase;
-            color: white;
-            font-size: 14px;
-            border-radius: 4px;
-            border: none;
-            display: inline-block;
-            margin-left: 16px;
-            padding: 16px;
-            padding-left: 24px;
-            padding-right: 24px;
-            outline: none;
-          }
-
-          .btn.save {
-            background: #8bc34a;
-          }
-
-          .btn.cancel {
-            background: #e85454;
           }
         `}</style>
       </div>

--- a/components/Display/Display.js
+++ b/components/Display/Display.js
@@ -46,13 +46,7 @@ class Display extends React.Component {
     return (
       <Frame>
         <div className={'gridContainer'} ref={ref => (this.container = ref)}>
-          <GridLayoutWithHeight
-            className='layout'
-            isDraggable={false}
-            isResizable={false}
-            layout={layout}
-            cols={6}
-          >
+          <GridLayoutWithHeight className='layout' static={true} layout={layout} cols={6}>
             {widgets.map(widget => {
               const Widget = Widgets[widget.type] ? Widgets[widget.type].Widget : EmptyWidget
               return (

--- a/components/Form/Button.js
+++ b/components/Form/Button.js
@@ -1,0 +1,33 @@
+import React from 'react'
+
+class Button extends React.Component {
+  render() {
+    const { onClick = () => {}, text = 'Submit', color = 'gray' } = this.props
+    return (
+      <button className={'btn save'} onClick={onClick}>
+        {text}
+        <style jsx>{`
+          .btn {
+            font-family: 'Open Sans', sans-serif;
+            background: lightgray;
+            text-decoration: none;
+            text-transform: uppercase;
+            color: white;
+            font-size: 14px;
+            border-radius: 4px;
+            border: none;
+            display: inline-block;
+            margin-left: 16px;
+            padding: 16px;
+            padding-left: 24px;
+            padding-right: 24px;
+            outline: none;
+            background: ${color};
+          }
+        `}</style>
+      </button>
+    )
+  }
+}
+
+export default Button

--- a/components/Form/ButtonGroup.js
+++ b/components/Form/ButtonGroup.js
@@ -1,0 +1,22 @@
+import React from 'react'
+
+class ButtonGroup extends React.Component {
+  render() {
+    const { children } = this.props
+    return (
+      <div className={'btnGroup'}>
+        {children}
+        <style jsx>{`
+          .btnGroup {
+            display: flex;
+            flex-direction: row;
+            justify-content: flex-end;
+            flex: 1;
+          }
+        `}</style>
+      </div>
+    )
+  }
+}
+
+export default ButtonGroup

--- a/components/Form/Form.js
+++ b/components/Form/Form.js
@@ -1,0 +1,20 @@
+import React from 'react'
+
+class Form extends React.Component {
+  render() {
+    const { children } = this.props
+    return (
+      <div className={'form'}>
+        {children}
+        <style jsx>{`
+          .form {
+            display: flex;
+            flex-direction: column;
+          }
+        `}</style>
+      </div>
+    )
+  }
+}
+
+export default Form

--- a/components/Form/Input.js
+++ b/components/Form/Input.js
@@ -19,7 +19,7 @@ class Input extends React.Component {
   }
 
   render() {
-    const { label, type = 'text', placeholder = '' } = this.props
+    const { label, inline = true, type = 'text', placeholder = '', choices = [] } = this.props
     const { value = '' } = this.state
 
     return (
@@ -32,6 +32,15 @@ class Input extends React.Component {
             value={value}
             onChange={this.handleInputChange}
           />
+        ) : type == 'select' ? (
+          <select onChange={this.handleInputChange}>
+            <option value={''}>Choose an option...</option>
+            {choices.map(choice => (
+              <option key={choice.id} value={choice.id} selected={value == choice.id}>
+                {choice.label}
+              </option>
+            ))}
+          </select>
         ) : (
           <textarea onChange={this.handleInputChange} value={value} />
         )}
@@ -39,7 +48,7 @@ class Input extends React.Component {
           .inputGroup {
             margin-bottom: 16px;
             display: flex;
-            flex-direction: row;
+            flex-direction: ${inline ? 'row' : 'column'};
             justify-content: flex-start;
           }
 
@@ -48,13 +57,15 @@ class Input extends React.Component {
             color: #878787;
             font-family: 'Open Sans', sans-serif;
             min-width: 100px;
-            max-width: 100px;
+            max-width: ${inline ? '100px' : 'none'};
             display: inline-block;
             padding-top: 16px;
+            padding-bottom: ${inline ? '0px' : '16px'};
           }
 
           input,
-          textarea {
+          textarea,
+          select {
             background-color: #f7f7f7;
             min-height: 40px;
             min-width: 450px;
@@ -70,6 +81,12 @@ class Input extends React.Component {
           textarea {
             resize: vertical;
             min-height: 100px;
+          }
+
+          select {
+            -webkit-appearance: none;
+            -moz-appearance: none;
+            appearance: none;
           }
 
           input[type='number'] {

--- a/components/Form/Input.js
+++ b/components/Form/Input.js
@@ -1,0 +1,85 @@
+import React from 'react'
+
+class Input extends React.Component {
+  constructor(props) {
+    super(props)
+    const { value } = this.props
+    this.state = {
+      value
+    }
+  }
+  handleInputChange = event => {
+    const { onChange = () => {}, name = '' } = this.props
+    const target = event.target
+    const value = target.value
+
+    this.setState({ value }, () => {
+      onChange(name, value)
+    })
+  }
+
+  render() {
+    const { label, type = 'text', placeholder = '' } = this.props
+    const { value = '' } = this.state
+
+    return (
+      <div className='inputGroup'>
+        {label && <label>{label}</label>}
+        {type == 'text' || type == 'password' || type == 'number' ? (
+          <input
+            type={type}
+            placeholder={placeholder}
+            value={value}
+            onChange={this.handleInputChange}
+          />
+        ) : (
+          <textarea onChange={this.handleInputChange} value={value} />
+        )}
+        <style jsx>{`
+          .inputGroup {
+            margin-bottom: 16px;
+            display: flex;
+            flex-direction: row;
+            justify-content: flex-start;
+          }
+
+          label {
+            margin-right: 16px;
+            color: #878787;
+            font-family: 'Open Sans', sans-serif;
+            min-width: 100px;
+            max-width: 100px;
+            display: inline-block;
+            padding-top: 16px;
+          }
+
+          input,
+          textarea {
+            background-color: #f7f7f7;
+            min-height: 40px;
+            min-width: 450px;
+            border-radius: 2px;
+            border: none;
+            outline: none;
+            padding: 8px;
+            padding-left: 16px;
+            padding-right: 16px;
+            font-size: 16px;
+          }
+
+          textarea {
+            resize: vertical;
+            min-height: 100px;
+          }
+
+          input[type='number'] {
+            min-width: 50px !important;
+            max-width: 50px !important;
+          }
+        `}</style>
+      </div>
+    )
+  }
+}
+
+export default Input

--- a/components/Form/index.js
+++ b/components/Form/index.js
@@ -1,0 +1,6 @@
+import Button from './Button'
+import ButtonGroup from './ButtonGroup'
+import Form from './Form'
+import Input from './Input'
+
+export { Form, Input, ButtonGroup, Button }

--- a/components/List.js
+++ b/components/List.js
@@ -1,19 +1,10 @@
 import { Component } from 'react'
 import React from 'react'
-import Dialog from './Dialog'
-import {
-  SortableContainer,
-  SortableElement,
-  arrayMove
-} from 'react-sortable-hoc'
+import SlideEditDialog from './Admin/SlideEditDialog'
+import { SortableContainer, SortableElement, arrayMove } from 'react-sortable-hoc'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faClock } from '@fortawesome/free-regular-svg-icons'
-import {
-  faTrash,
-  faEdit,
-  faPlay,
-  faGlobe
-} from '@fortawesome/free-solid-svg-icons'
+import { faTrash, faEdit, faPlay, faGlobe } from '@fortawesome/free-solid-svg-icons'
 
 /* eslint-disable */
 const MOCK_SLIDES = [
@@ -61,7 +52,7 @@ const MOCK_SLIDES = [
 class Card extends Component {
   constructor(props) {
     super(props)
-    this.modal = React.createRef()
+    this.dialog = React.createRef()
   }
   render() {
     const { value } = this.props
@@ -82,20 +73,10 @@ class Card extends Component {
             }}
           >
             {value.type == 'youtube' && (
-              <FontAwesomeIcon
-                icon={faPlay}
-                fixedWidth
-                size='lg'
-                color='#FFFFFF'
-              />
+              <FontAwesomeIcon icon={faPlay} fixedWidth size='lg' color='#FFFFFF' />
             )}
             {value.type == 'web' && (
-              <FontAwesomeIcon
-                icon={faGlobe}
-                fixedWidth
-                size='lg'
-                color='#FFFFFF'
-              />
+              <FontAwesomeIcon icon={faGlobe} fixedWidth size='lg' color='#FFFFFF' />
             )}
           </div>
         </div>
@@ -114,14 +95,14 @@ class Card extends Component {
               icon={faEdit}
               fixedWidth
               color='#828282'
-              onClick={() => this.modal && this.modal.current.openModal()}
+              onClick={() => this.dialog && this.dialog.current.open()}
             />
           </div>
           <div className='actionIcon'>
             <FontAwesomeIcon icon={faTrash} fixedWidth color='#828282' />
           </div>
         </div>
-        <Dialog ref={this.modal} />
+        <SlideEditDialog ref={this.dialog} />
         <style jsx>
           {`
             .card {
@@ -265,12 +246,7 @@ class List extends Component {
   }
   render() {
     return (
-      <SortableList
-        items={this.state.items}
-        onSortEnd={this.onSortEnd}
-        distance={2}
-        lockAxis='y'
-      />
+      <SortableList items={this.state.items} onSortEnd={this.onSortEnd} distance={2} lockAxis='y' />
     )
   }
 }

--- a/components/Upload.js
+++ b/components/Upload.js
@@ -1,20 +1,20 @@
 import { Component } from 'react'
 import React from 'react'
 import Dropzone from 'react-dropzone'
-import Dialog from './Dialog.js'
+import SlideEditDialog from './Admin/SlideEditDialog.js'
 import axios from 'axios'
 
 class Upload extends Component {
   constructor(props) {
     super(props)
-    this.modal = React.createRef()
+    this.dialog = React.createRef()
   }
 
   handleOnDropAccepted = acceptedFiles => {
     const formData = new FormData()
     formData.append('data', acceptedFiles[acceptedFiles.length - 1])
-    
-    this.modal && this.modal.current.openModal()
+
+    this.dialog && this.dialog.current.open()
 
     axios.post('/api/v1/slide', formData, {
       headers: {
@@ -32,7 +32,7 @@ class Upload extends Component {
   render() {
     return (
       <div>
-        <Dialog ref={this.modal} />
+        <SlideEditDialog ref={this.dialog} />
         <Dropzone
           accept='image/*'
           onDropAccepted={this.handleOnDropAccepted}
@@ -52,7 +52,6 @@ class Upload extends Component {
             )
           }}
         </Dropzone>
-        <Dialog ref={this.modal} />
         <style jsx>
           {`
             .upload {

--- a/components/Widgets/EmptyWidgetOptions.js
+++ b/components/Widgets/EmptyWidgetOptions.js
@@ -12,6 +12,8 @@ class EmptyWidgetOptions extends React.Component {
               flex-direction: column;
               justify-content: center;
               text-align: center;
+              padding: 20px;
+              font-family: 'Open Sans', sans-serif;
             }
           `}
         </style>

--- a/pages/layout.js
+++ b/pages/layout.js
@@ -2,7 +2,7 @@ import React from 'react'
 import GridLayout from 'react-grid-layout'
 
 import Frame from '../components/Admin/Frame.js'
-import EditableWidget from '../components/Widgets/EditableWidget'
+import EditableWidget from '../components/Admin/EditableWidget'
 import WidthProvider from '../components/Widgets/WidthProvider'
 import DropdownButton from '../components/DropdownButton'
 
@@ -83,10 +83,12 @@ class Layout extends React.Component {
           layout={layout}
           cols={6}
           onLayoutChange={this.onLayoutChange}
+          draggableCancel={'.ReactModalPortal'}
         >
           {widgets.map(widget => (
             <div key={widget._id}>
               <EditableWidget
+                id={widget._id}
                 type={widget.type}
                 onDelete={this.deleteWidget.bind(this, widget._id)}
               />

--- a/widgets/slideshow/index.js
+++ b/widgets/slideshow/index.js
@@ -1,5 +1,6 @@
 import BaseWidget from '../base_widget'
-import SlideshowRenderer from './src/SlideshowRenderer.js'
+import SlideshowContent from './src/Slideshow.js'
+import SlideshowOptions from './src/SlideshowOptions.js'
 
 export default class Slideshow extends BaseWidget {
   constructor() {
@@ -11,6 +12,10 @@ export default class Slideshow extends BaseWidget {
   }
 
   get Widget() {
-    return SlideshowRenderer
+    return SlideshowContent
+  }
+
+  get Options() {
+    return SlideshowOptions
   }
 }

--- a/widgets/slideshow/src/Slideshow.js
+++ b/widgets/slideshow/src/Slideshow.js
@@ -59,7 +59,7 @@ const DEFAULT_SLIDES = [
 ]
 /* eslint-enable */
 
-class SlideshowRenderer extends Component {
+class Slideshow extends Component {
   constructor(props) {
     super(props)
 
@@ -197,4 +197,4 @@ class SlideshowRenderer extends Component {
   }
 }
 
-export default SlideshowRenderer
+export default Slideshow

--- a/widgets/slideshow/src/SlideshowOptions.js
+++ b/widgets/slideshow/src/SlideshowOptions.js
@@ -1,0 +1,57 @@
+import React, { Component } from 'react'
+import { Form, Input } from '../../../components/Form'
+import { getSlideshows } from '../../../actions/slideshow'
+
+class SlideshowOptions extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      slideshows: []
+    }
+  }
+  handleChange = (name, value) => {
+    const { onChange = () => {} } = this.props
+    if (name == 'slideShowId') {
+      onChange(value)
+    }
+  }
+
+  componentDidMount() {
+    getSlideshows().then(data => {
+      const slideshows = data.map(slideshow => ({
+        id: slideshow._id,
+        label: slideshow.title || 'Untitled slideshow'
+      }))
+      this.setState({ slideshows })
+    })
+  }
+
+  render() {
+    const { data } = this.props
+    const { slideshows } = this.state
+    return (
+      <Form>
+        <h3>Widget: Slideshow</h3>
+        <p>Select which slideshow you would like this widget to display</p>
+        <Input
+          inline={false}
+          type={'select'}
+          name={'slideShowId'}
+          value={data}
+          onChange={this.handleChange}
+          choices={slideshows}
+        />
+        <style jsx>
+          {`
+            h3,
+            p {
+              font-family: 'Open Sans', sans-serif;
+            }
+          `}
+        </style>
+      </Form>
+    )
+  }
+}
+
+export default SlideshowOptions


### PR DESCRIPTION
Closes #58 

<img width="959" alt="Screen Shot 2019-04-11 at 8 48 28 PM" src="https://user-images.githubusercontent.com/591655/56004819-493e0b80-5c9b-11e9-8045-fec0244f90c9.png">

This PR creates the infrastructure that enables developers to create administrator panels for their widgets. It also includes an example for using the interface for the slideshow widget (allows the user to choose which slideshow to display).

### Changes
- Creates infrastructure for creating admin panels
- Implements the interface for the Slideshow widget (choosing which slideshow to show)
- Refactors code for form elements (buttons, input, button groups, etc) that are shared between admin interfaces (splits code from @binicij 's `Dialog` into multiple smaller components)