### PR TITLE
Widgets: Create a standalone image widget

### DIFF
--- a/actions/slide.js
+++ b/actions/slide.js
@@ -46,3 +46,13 @@ export const addSlide = (slideshow, file, data, host = '') => {
     }
   })
 }
+
+export const standaloneUpload = (file, host = '') => {
+  const formData = new FormData()
+  formData.append('data', file)
+  return axios.post(host + '/api/v1/slide/standalone_upload', formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data'
+    }
+  })
+}

--- a/api/routes/slide.js
+++ b/api/routes/slide.js
@@ -54,7 +54,7 @@ router
 router.post('/standalone_upload', upload.single('data'), (req, res, next) => {
   if (!req.file || !req.file.path) return next(new Error('Missing file upload'))
 
-  return '/' + req.file.path
+  return res.json({ success: true, url: '/' + req.file.path })
 })
 
 // Route: /api/v1/slide/:id

--- a/components/Admin/EditableWidget.js
+++ b/components/Admin/EditableWidget.js
@@ -66,12 +66,14 @@ class EditableWidget extends React.Component {
             .widget {
               background-color: rgba(108, 108, 108, 1);
               border-radius: 6px;
-              width: 100%;
-              height: 100%;
+              width: calc(100% - 16px);
+              height: calc(100% - 16px);
+              padding: 8px;
               display: flex;
               flex-direction: column;
               justify-content: center;
               cursor: move;
+              overflow: hidden;
             }
             .widget .info {
               display: flex;
@@ -88,7 +90,11 @@ class EditableWidget extends React.Component {
               color: white;
               font-family: 'Open Sans', sans-serif;
               text-transform: uppercase;
-              font-size: 16px;
+              font-size: 14px;
+              white-space: nowrap;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              max-width: 100%;
             }
             .widget .info .name {
               color: white;

--- a/components/Admin/Sidebar.js
+++ b/components/Admin/Sidebar.js
@@ -139,7 +139,7 @@ const Sidebar = ({ router }) => (
           line-height: 16px;
           padding-right: 4px;
         }
-        @media only screen and (max-width: 600px) {
+        @media only screen and (max-width: 900px) {
           .sidebar {
             min-width: 0px;
           }

--- a/components/Form/ColorPicker.js
+++ b/components/Form/ColorPicker.js
@@ -30,8 +30,8 @@ export default class ColorPicker extends React.Component {
     const styles = reactCSS({
       default: {
         color: {
-          width: '46px',
-          height: '30px',
+          width: '64px',
+          height: '42px',
           borderRadius: '2px',
           background: this.state.color
         },

--- a/components/Form/Input.js
+++ b/components/Form/Input.js
@@ -107,7 +107,7 @@ class Input extends React.Component {
               return (
                 <div {...getRootProps()} className='upload'>
                   <input {...getInputProps()} />
-                  {isDragActive || value == '' ? (
+                  {isDragActive || (!value || value == '') ? (
                     <div className={'photo-upload'}>Drop a photo here...</div>
                   ) : (
                     <div className={'photo'}>
@@ -137,7 +137,7 @@ class Input extends React.Component {
         <style jsx>{`
           .inputGroup {
             margin-bottom: 16px;
-            display: ${expand ? 'flex' : 'inline-block'};
+            display: ${!inline ? 'flex' : 'inline-block'};
             flex-direction: ${inline ? 'row' : 'column'};
             justify-content: flex-start;
           }
@@ -188,6 +188,7 @@ class Input extends React.Component {
             -webkit-appearance: none;
             -moz-appearance: none;
             appearance: none;
+            padding: 16px;
           }
 
           input[type='number'] {

--- a/widgets/image/index.js
+++ b/widgets/image/index.js
@@ -2,7 +2,7 @@ import BaseWidget from '../base_widget'
 import ImageContent from './src/ImageContent'
 import ImageOptions from './src/ImageOptions'
 
-export default class Web extends BaseWidget {
+export default class Image extends BaseWidget {
   constructor() {
     super({
       name: 'Image',

--- a/widgets/image/index.js
+++ b/widgets/image/index.js
@@ -1,0 +1,27 @@
+import BaseWidget from '../base_widget'
+import ImageContent from './src/ImageContent'
+import ImageOptions from './src/ImageOptions'
+
+export default class Web extends BaseWidget {
+  constructor() {
+    super({
+      name: 'Image',
+      version: '0.1',
+      icon: 'image',
+      defaultData: {
+        title: null,
+        url: null,
+        fit: 'contain',
+        color: '#2d3436'
+      }
+    })
+  }
+
+  get Widget() {
+    return ImageContent
+  }
+
+  get Options() {
+    return ImageOptions
+  }
+}

--- a/widgets/image/src/ImageContent.js
+++ b/widgets/image/src/ImageContent.js
@@ -1,0 +1,109 @@
+/**
+ * @fileoverview Slideshow component that given an array of slide descriptions
+ * of mixed types, renders the slides and automatically plays the slideshow for
+ * the given durations
+ */
+
+import React, { Component } from 'react'
+import { config } from '@fortawesome/fontawesome-svg-core'
+
+config.autoAddCss = false
+
+const DEFAULT_COLOR = '#2d3436'
+const DEFAULT_FIT = 'contain'
+
+class ImageContent extends Component {
+  constructor(props) {
+    super(props)
+    this.iframe = React.createRef()
+  }
+
+  render() {
+    const { data: { title, url, fit = DEFAULT_FIT, color = DEFAULT_COLOR } = {} } = this.props
+    return (
+      <div className='image'>
+        {title && (
+          <div className='titleConainer'>
+            <div className='title'>{title}</div>
+          </div>
+        )}
+        <div className='content' style={{ background: color }}>
+          <div
+            className='photocover'
+            style={{
+              backgroundImage: `url(${url})`
+            }}
+          />
+          <div
+            className='photo'
+            style={{
+              backgroundImage: `url(${url})`
+            }}
+          />
+        </div>
+        <style jsx>
+          {`
+            .image {
+              position: relative;
+              box-sizing: border-box;
+              height: 100%;
+              width: 100%;
+              background: ${color};
+              flex: 1;
+              font-family: 'Open Sans', sans-serif;
+              display: flex;
+              flex-direction: column;
+            }
+            .image .content {
+              flex: 1;
+              border: none;
+              overflow: hidden;
+              position: relative;
+            }
+            .image .titleConainer {
+              padding: 12px;
+            }
+            .image .title {
+              font-family: 'Open Sans', sans-serif;
+              border-left: 3px solid rgba(255, 255, 255, 0.5);
+              font-size: 16px;
+              padding-left: 12px;
+              font-weight: 600;
+              text-transform: uppercase;
+              z-index: 1;
+            }
+            .photocover {
+              width: 110%;
+              height: 110%;
+              background-size: cover;
+              background-repeat: no-repeat;
+              background-position: 50% 50%;
+              filter: blur(20px);
+              position: absolute;
+              top: -5%;
+              left: -5%;
+            }
+            .photo {
+              width: 100%;
+              height: 100%;
+              background-size: ${fit};
+              background-repeat: no-repeat;
+              background-position: 50% 50%;
+              position: absolute;
+              top: 0;
+              left: 0;
+            }
+            .invisible {
+              width: 1px;
+              height: 1px;
+              display: none;
+              visibility: hidden;
+            }
+          `}
+        </style>
+      </div>
+    )
+  }
+}
+
+export default ImageContent

--- a/widgets/image/src/ImageOptions.js
+++ b/widgets/image/src/ImageOptions.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import { Form, Input, InlineInputGroup } from '../../../components/Form'
 import { standaloneUpload } from '../../../actions/slide'
 
-class WebOptions extends Component {
+class ImageOptions extends Component {
   constructor(props) {
     super(props)
     const { title, color, fit, url } = props.data || {}
@@ -99,4 +99,4 @@ class WebOptions extends Component {
   }
 }
 
-export default WebOptions
+export default ImageOptions

--- a/widgets/image/src/ImageOptions.js
+++ b/widgets/image/src/ImageOptions.js
@@ -1,0 +1,102 @@
+import React, { Component } from 'react'
+import { Form, Input, InlineInputGroup } from '../../../components/Form'
+import { standaloneUpload } from '../../../actions/slide'
+
+class WebOptions extends Component {
+  constructor(props) {
+    super(props)
+    const { title, color, fit, url } = props.data || {}
+    this.state = {
+      title,
+      color,
+      fit,
+      url
+    }
+  }
+
+  handleChange = async (name, value) => {
+    const { onChange = () => {} } = this.props
+    if (name == 'upload') {
+      name = 'url'
+      const resp = await standaloneUpload(value)
+      value = resp.data.url
+    }
+    this.setState(
+      {
+        [name]: value
+      },
+      () => {
+        onChange(this.state)
+      }
+    )
+  }
+
+  render() {
+    const { title, color, fit, url } = this.state
+    return (
+      <div className={'container'}>
+        <Form>
+          <h3>Widget: Standalone Image</h3>
+          <p>Choose your preferences for the image widget.</p>
+          <InlineInputGroup>
+            <Input
+              inline={false}
+              label={'Background'}
+              type={'color'}
+              name={'color'}
+              value={color}
+              onChange={this.handleChange}
+              expand={false}
+            />
+            <Input
+              inline={false}
+              label={'Title (Optional)'}
+              type={'text'}
+              name={'title'}
+              value={title}
+              onChange={this.handleChange}
+              expand={true}
+            />
+          </InlineInputGroup>
+          <InlineInputGroup>
+            <Input
+              inline={false}
+              label={'Image'}
+              type={'photo'}
+              name={'url'}
+              value={url}
+              onChange={this.handleChange}
+            />
+            <Input
+              inline={false}
+              label={'Image fit'}
+              type={'select'}
+              name={'fit'}
+              value={fit}
+              choices={[
+                { label: 'Zoom-in (Cover)', id: 'cover' },
+                { label: 'Fit to Container', id: 'contain' }
+              ]}
+              onChange={this.handleChange}
+              expand={false}
+            />
+          </InlineInputGroup>
+        </Form>
+        <style jsx>
+          {`
+            h3,
+            p {
+              font-family: 'Open Sans', sans-serif;
+            }
+            .container {
+              display: flex;
+              flex-direction: column;
+            }
+          `}
+        </style>
+      </div>
+    )
+  }
+}
+
+export default WebOptions

--- a/widgets/list.js
+++ b/widgets/list.js
@@ -1,1 +1,1 @@
-module.exports = ['slideshow', 'weather', 'congrats', 'youtube', 'web']
+module.exports = ['slideshow', 'weather', 'congrats', 'youtube', 'web', 'image']


### PR DESCRIPTION
This PR adds  a new widget that displays a single image. Options for the widget include adding a title, background color and choosing whether to zoom in the image or not.

### Screenshots

Options:
<img width="771" alt="Screen Shot 2019-05-12 at 4 14 42 PM" src="https://user-images.githubusercontent.com/591655/57587325-63a11a00-74d1-11e9-973e-5f1690914f05.png">


Image (Zoomed in):
<img width="314" alt="Screen Shot 2019-05-12 at 4 15 32 PM" src="https://user-images.githubusercontent.com/591655/57587329-6996fb00-74d1-11e9-97ba-d03bb602a326.png">

Image (Fit to container):
<img width="317" alt="Screen Shot 2019-05-12 at 4 15 22 PM" src="https://user-images.githubusercontent.com/591655/57587332-6ef44580-74d1-11e9-9c69-7db23096331e.png">
